### PR TITLE
Enable building and running benchmarks with JDKs 21 and 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,6 @@
     </licenses>
 
     <properties>
-        <java.source.version>25</java.source.version>
-        <java.target.version>25</java.target.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jmh.version>1.36</jmh.version>
@@ -82,11 +80,6 @@
                     <source>${java.source.version}</source>
                     <target>${java.target.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
-                    <compilerArgs>
-                        <arg>-proc:full</arg>
-                        <arg>-h</arg>
-                        <arg>${project.build.directory}/nar/javah-include</arg>
-                    </compilerArgs>
                 </configuration>
             </plugin>
 
@@ -108,9 +101,6 @@
                             <option>-O3</option>
                         </options>
                     </cpp>
-                    <javah>
-                        <skip>true</skip>
-                    </javah>
                 </configuration>
             </plugin>
 
@@ -238,4 +228,82 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>java1.8</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <properties>
+                <java.source.version>1.8</java.source.version>
+                <java.target.version>1.8</java.target.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>java21</id>
+            <activation>
+                <jdk>21</jdk>
+            </activation>
+            <properties>
+                <java.source.version>21</java.source.version>
+                <java.target.version>21</java.target.version>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:full</arg>
+                                <arg>-h</arg>
+                                <arg>${project.build.directory}/nar/javah-include</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.maven-nar</groupId>
+                        <artifactId>nar-maven-plugin</artifactId>
+                        <configuration>
+                            <javah>
+                                <skip>true</skip>
+                            </javah>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>java25</id>
+            <activation>
+                <jdk>25</jdk>
+            </activation>
+            <properties>
+                <java.source.version>25</java.source.version>
+                <java.target.version>25</java.target.version>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-proc:full</arg>
+                                <arg>-h</arg>
+                                <arg>${project.build.directory}/nar/javah-include</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.maven-nar</groupId>
+                        <artifactId>nar-maven-plugin</artifactId>
+                        <configuration>
+                            <javah>
+                                <skip>true</skip>
+                            </javah>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
                     <source>${java.source.version}</source>
                     <target>${java.target.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <compilerArgs>
+                        <arg>-h</arg>
+                        <arg>${project.build.directory}/nar/javah-include</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
 
@@ -103,6 +107,9 @@
                             <option>-O3</option>
                         </options>
                     </cpp>
+                    <javah>
+                        <skip>true</skip>
+                    </javah>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -240,14 +240,10 @@
             </properties>
         </profile>
         <profile>
-            <id>java21</id>
+            <id>java9+</id>
             <activation>
-                <jdk>21</jdk>
+                <jdk>[9,)</jdk>
             </activation>
-            <properties>
-                <java.source.version>21</java.source.version>
-                <java.target.version>21</java.target.version>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -273,6 +269,16 @@
             </build>
         </profile>
         <profile>
+            <id>java21</id>
+            <activation>
+                <jdk>21</jdk>
+            </activation>
+            <properties>
+                <java.source.version>21</java.source.version>
+                <java.target.version>21</java.target.version>
+            </properties>
+        </profile>
+        <profile>
             <id>java25</id>
             <activation>
                 <jdk>25</jdk>
@@ -281,29 +287,6 @@
                 <java.source.version>25</java.source.version>
                 <java.target.version>25</java.target.version>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <compilerArgs>
-                                <arg>-proc:full</arg>
-                                <arg>-h</arg>
-                                <arg>${project.build.directory}/nar/javah-include</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>com.github.maven-nar</groupId>
-                        <artifactId>nar-maven-plugin</artifactId>
-                        <configuration>
-                            <javah>
-                                <skip>true</skip>
-                            </javah>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
                     <target>${java.target.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <compilerArgs>
+                        <arg>-proc:full</arg>
                         <arg>-h</arg>
                         <arg>${project.build.directory}/nar/javah-include</arg>
                     </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
     </licenses>
 
     <properties>
-        <java.source.version>1.8</java.source.version>
-        <java.target.version>1.8</java.target.version>
+        <java.source.version>25</java.source.version>
+        <java.target.version>25</java.target.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jmh.version>1.36</jmh.version>


### PR DESCRIPTION
By default, the `nar-maven-plugin` tries to use the `javah` tool which was removed in JDK 10. The functionality has been merged into `javac` which requires additional command line parameters.